### PR TITLE
support on_error in parallel executor

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core
+  colcon-core>=0.3.15
 packages = find:
 tests_require =
   flake8

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
 [colcon-parallel-executor]
-Depends3: python3-colcon-core
+Depends3: python3-colcon-core (>= 0.3.15)
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
Requires colcon/colcon-core#145 to be released.

Supports the on-error argument in the parallel executor.