### PR TITLE
consider sched_getaffinity when limiting parallel workers

### DIFF
--- a/colcon_parallel_executor/executor/parallel.py
+++ b/colcon_parallel_executor/executor/parallel.py
@@ -38,6 +38,12 @@ class ParallelExecutorExtension(ExecutorExtensionPoint):
 
     def add_arguments(self, *, parser):  # noqa: D102
         max_workers_default = os.cpu_count() or 4
+        try:
+            # consider restricted set of CPUs if applicable
+            max_workers_default = min(
+                max_workers_default, len(os.sched_getaffinity(0)))
+        except AttributeError:
+            pass
         parser.add_argument(
             '--parallel-workers',
             type=int,

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,7 @@ apache
 asyncio
 colcon
 coroutine
+getaffinity
 iscoroutinefunction
 iterdir
 noqa


### PR DESCRIPTION
Since some CI providers like Circle CI limit the CPUs allocated to the container it is beneficial to use that information for the maximum number of workers.

Similar to colcon/colcon-cmake#37.