### PR TITLE
-j for jobs

### DIFF
--- a/colcon_parallel_executor/executor/parallel.py
+++ b/colcon_parallel_executor/executor/parallel.py
@@ -45,6 +45,7 @@ class ParallelExecutorExtension(ExecutorExtensionPoint):
                 max_workers_default, len(os.sched_getaffinity(0)))
         parser.add_argument(
             '--parallel-workers',
+            '-j', '--jobs',  # Bonus aliases for maximum flexibility
             type=int,
             default=max_workers_default,
             metavar='NUMBER',


### PR DESCRIPTION
Both `catkin_make` and `catkin_tools` use `-j`/`--jobs` to specify the number of parallel workers. This PR adds those to the argparse parser as aliases. 